### PR TITLE
fcntl.ioctl() is placing an ioctl (http://en.wikipedia.org/wiki/Ioctl) c...

### DIFF
--- a/wifijammer.py
+++ b/wifijammer.py
@@ -124,7 +124,6 @@ def remove_mon_iface():
 def mon_mac(mon_iface):
     '''
     http://stackoverflow.com/questions/159137/getting-mac-address
-    I don't know what the hell is going on here other than we're opening a socket
     '''
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     info = fcntl.ioctl(s.fileno(), 0x8927, struct.pack('256s', mon_iface[:15]))


### PR DESCRIPTION
...all to the opened socket.

In C land, an ioctl call would be: ioctl(fd, command, argument), where fd is the file descriptor
of the driver/file/socket/pipe/etc. you're querying, command is a constant defining which command
you're calling, and argument is an arbitrary value (but is usually a pointer to a struct with
user input).

This calling convention is similar in Python land, with fd being provided by: s.fileno(), command
hardcoded to 0x8927, and argument being a string of the interface name.

If we grep the Linux kernel source, we find that 0x8927 corresponds to this command:

$ grep 0x8927 -r include/
include/linux/sockios.h:#define SIOCGIFHWADDR   0x8927      /\* Get hardware address     */

man netdevice(7) explains use of the SIOCGIFHWADDR command, and how it returns the interface's
hardware (MAC) address.

The ''.join() line is simply formatting the returned data into a human-readable MAC address.
