### PR TITLE
Fix shebang

### DIFF
--- a/wifijammer.py
+++ b/wifijammer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: UTF-8 -*-
 
 import logging


### PR DESCRIPTION
I changed the shebang to `#!/usr/bin/env python2`, since `python` is linked to `python3` is some recent distros, which prevented it from working correctly.