### PR TITLE
Fix dry-run output

### DIFF
--- a/wifijammer.py
+++ b/wifijammer.py
@@ -288,7 +288,8 @@ def deauth(monchannel):
 
 def output(err, monchannel):
     os.system('clear')
-    print P+'***DRY-RUN***'+W
+    if args.dry_run:
+        print P+'***DRY-RUN***'+W
     if err:
         print err
     else:


### PR DESCRIPTION
`***DRY-RUN***` is always showed even if its not in dry-run mode. This PR fixes that.