### PR TITLE
Parse args before root check

### DIFF
--- a/wifijammer
+++ b/wifijammer
@@ -436,13 +436,13 @@ def stop(signal, frame):
         sys.exit('\n['+R+'!'+W+'] Closing')
 
 if __name__ == "__main__":
+    args = parse_args()
     if os.geteuid():
         sys.exit('['+R+'-'+W+'] Please run as root')
     clients_APs = []
     APs = []
     DN = open(os.devnull, 'w')
     lock = Lock()
-    args = parse_args()
     args.skip = list(map(str.lower, args.skip))
     # lowercase bssids while leaving essids intact
     args.accesspoint = set(_.lower() if ':' in _ else _ for _ in args.accesspoint)


### PR DESCRIPTION
Just moved the argument parse step before the root check. This way you can see all the flags as a non-root user.

Since wifijammer doesn't have a man page it is useful to have a terminal open with the printed help info beside the root terminal wifijammer is running in. It is annoying to have to type in a root password every time you just want to look up some flags.