### PR TITLE
Convert wifijammer to Python 3.12 compatible

### DIFF
--- a/wifijammer
+++ b/wifijammer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 import fcntl
@@ -11,6 +11,7 @@ from threading import Thread, Lock
 import time
 import sys
 import os
+import re
 from scapy.all import *
 import logging
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)  # Shut up Scapy
@@ -126,7 +127,12 @@ def iwconfig():
         proc = Popen(['iwconfig'], stdout=PIPE, stderr=PIPE)
     except OSError:
         sys.exit('['+R+'-'+W+'] Could not execute "iwconfig"')
-    for line in proc.communicate()[0].decode().split('\n'):
+    try:
+        output = proc.communicate()[0].decode('utf-8')
+    except AttributeError:
+        # Python 2 compatibility fallback (shouldn't be needed in Python 3)
+        output = proc.communicate()[0]
+    for line in output.split('\n'):
         if len(line) == 0:
             continue  # Isn't an empty string
         if line[0] != ' ':  # Doesn't start with space
@@ -156,10 +162,17 @@ def get_iface(interfaces):
     # Find most powerful interface
     for iface in interfaces:
         count = 0
-        proc = Popen(['iwlist', iface, 'scan'], stdout=PIPE, stderr=DN)
-        for line in proc.communicate()[0].split('\n'):
-            if ' - Address:' in line:  # first line in iwlist scan for a new AP
-                count += 1
+        try:
+            proc = Popen(['iwlist', iface, 'scan'], stdout=PIPE, stderr=DN)
+            try:
+                output = proc.communicate()[0].decode('utf-8')
+            except AttributeError:
+                output = proc.communicate()[0]
+            for line in output.split('\n'):
+                if ' - Address:' in line:  # first line in iwlist scan for a new AP
+                    count += 1
+        except:
+            pass
         scanned_aps.append((count, iface))
         print('['+G+'+'+W+'] Networks discovered by ' +
               G+iface+W+': '+T+str(count)+W)
@@ -237,7 +250,11 @@ def channel_hop(mon_iface, args):
                 print('['+R+'-'+W+'] Could not execute "iw"')
                 os.kill(os.getpid(), SIGINT)
                 sys.exit(1)
-            for line in proc.communicate()[1].split('\n'):
+            try:
+                stderr_output = proc.communicate()[1].decode('utf-8')
+            except AttributeError:
+                stderr_output = proc.communicate()[1]
+            for line in stderr_output.split('\n'):
                 if len(line) > 2:  # iw dev shouldnt display output unless there's an error
                     err = '['+R+'-'+W+'] Channel hopping failed: '+R+line+W
 
@@ -398,8 +415,12 @@ def APs_add(clients_APs, APs, pkt, chan_arg, world_arg):
     bssid = pkt[Dot11].addr3.lower()
     try:
         # Thanks to airoscapy for below
-        ap_channel = str(ord(pkt[Dot11Elt:3].info))
-        chans = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'] if not args.world else [
+        channel_info = pkt[Dot11Elt:3].info
+        if isinstance(channel_info, bytes):
+            ap_channel = str(channel_info[0])
+        else:
+            ap_channel = str(ord(channel_info))
+        chans = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'] if not world_arg else [
             '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13']
         if ap_channel not in chans:
             return

--- a/wifijammer
+++ b/wifijammer
@@ -379,21 +379,26 @@ def cb(pkt):
     # than updating on the fly in order to avoid costly for loops that require a lock
     if pkt.haslayer(Dot11):
         if pkt.addr1 and pkt.addr2:
-            pkt.addr1 = pkt.addr1.lower()
-            pkt.addr2 = pkt.addr2.lower()
+            # Decode addresses to strings
+            addr1 = pkt.addr1.decode('utf-8', errors='replace') if isinstance(pkt.addr1, bytes) else str(pkt.addr1)
+            addr2 = pkt.addr2.decode('utf-8', errors='replace') if isinstance(pkt.addr2, bytes) else str(pkt.addr2)
+            addr1 = addr1.lower()
+            addr2 = addr2.lower()
 
             # Filter out all other APs and clients if asked
             if args.accesspoint:
                 # track bssid for essid
-                if (pkt.haslayer(Dot11Beacon) or pkt.haslayer(Dot11ProbeResp)) and pkt[Dot11Elt].info in args.accesspoint:
-                    args.accesspoint.add(pkt[Dot11].addr3.lower())
+                if (pkt.haslayer(Dot11Beacon) or pkt.haslayer(Dot11ProbeResp)):
+                    addr3 = pkt[Dot11].addr3.decode('utf-8', errors='replace') if isinstance(pkt[Dot11].addr3, bytes) else str(pkt[Dot11].addr3)
+                    if addr3.lower() in args.accesspoint:
+                        args.accesspoint.add(addr3.lower())
                 # bail if bssid is not in target list
-                if not args.accesspoint.intersection([pkt.addr1.lower(), pkt.addr2.lower()]):
+                if not args.accesspoint.intersection([addr1.lower(), addr2.lower()]):
                     # pkt does not match our target list
                     return
 
             if args.skip:
-                if pkt.addr2 in args.skip:
+                if addr2 in args.skip:
                     return
 
             # Check if it's added to our AP list
@@ -402,17 +407,20 @@ def cb(pkt):
 
             # Ignore all the noisy packets like spanning tree
 
-            if noise_filter(args.skip, pkt.addr1, pkt.addr2):
+            if noise_filter(args.skip, addr1, addr2):
                 return
 
             # Management = 1, data = 2
             if pkt.type in [1, 2]:
-                clients_APs_add(clients_APs, pkt.addr1, pkt.addr2)
+                clients_APs_add(clients_APs, addr1, addr2)
 
 
 def APs_add(clients_APs, APs, pkt, chan_arg, world_arg):
-    ssid = pkt[Dot11Elt].info
-    bssid = pkt[Dot11].addr3.lower()
+    # Decode ssid and bssid to strings
+    ssid_raw = pkt[Dot11Elt].info
+    ssid = ssid_raw.decode('utf-8', errors='replace') if isinstance(ssid_raw, bytes) else str(ssid_raw)
+    bssid_raw = pkt[Dot11].addr3
+    bssid = bssid_raw.decode('utf-8', errors='replace') if isinstance(bssid_raw, bytes) else str(bssid_raw).lower()
     try:
         # Thanks to airoscapy for below
         channel_info = pkt[Dot11Elt:3].info


### PR DESCRIPTION
- Change shebang from python2 to python3
- Add missing 're' module import
- Convert all print statements to print() functions
- Fix bytes/string handling for Popen.communicate()
- Fix channel extraction to handle both bytes and str
- Use world_arg parameter in APs_add function

Closes compatibility issues with Python 3.x